### PR TITLE
fix: title overlaps with the underline

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -109,7 +109,7 @@
         } else {
           ret.push(now)
         }
-        ret.push(v(-1em))
+        ret.push(v(-0.8em))
         ret.push(line(length: 100%))
         if c == "\n" {
           now = ""


### PR DESCRIPTION
好像是linespace重新设置的原因，主标题跟下面的下划线重叠了
先凑活修一下
（对不起，之前的PR漏掉了 :sob: ）